### PR TITLE
Fix duplicate otherdeliv

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,7 +7,6 @@ services:
       composer config repositories.ec-cube2-amazonpay-v2 '{\"type\": \"path\", \"url\": \"../composer\"}' &&
       composer require nanasess/ec-cube2-amazonpay-v2 "dev-main@dev" --ignore-platform-req=php -W &&
       patch -p1 < ../composer/patches/amazonpay.patch &&
-      cd data/vendor/amzn/amazon-pay-api-sdk-php && curl -sS -L https://patch-diff.githubusercontent.com/raw/amzn/amazon-pay-api-sdk-php/pull/35.diff | patch -p1 &&
       cd /var/www/app &&
       if [ $${DB_TYPE} == 'pgsql' ]; then /wait-for-pgsql.sh ls; else /wait-for-mysql.sh ls; fi &&
       export PGPASSWORD=$${DB_PASSWORD} &&

--- a/lib/data/class/helper/SC_Helper_AmazonPay.php
+++ b/lib/data/class/helper/SC_Helper_AmazonPay.php
@@ -140,11 +140,11 @@ class SC_Helper_AmazonPay
      *     billingAddress: array{
      *         postalCode: string,
      *         stateOrRegion: string,
-     *         City: string,
-     *         AddressLine1: string,
-     *         AddressLine2: string,
-     *         AddressLine3: string,
-     *         Phone: string,
+     *         city: string,
+     *         addressLine1: string,
+     *         addressLine2: string,
+     *         addressLine3: string,
+     *         phoneNumber: string,
      *     }
      * } $buyer
      * @param array{

--- a/lib/data/class/pages/shopping/LC_Page_Shopping_AmazonPay.php
+++ b/lib/data/class/pages/shopping/LC_Page_Shopping_AmazonPay.php
@@ -57,6 +57,8 @@ class LC_Page_Shopping_AmazonPay extends LC_Page_Cart_Ex
                 $this->lfSetCurrentCart($objSiteSess, $objCartSess, $cartKey);
                 $checkoutSessionId = htmlspecialchars($_GET['amazonCheckoutSessionId'], ENT_QUOTES);
                 $objAmazonPay = new SC_Helper_AmazonPay();
+                // 配送先が設定されている場合は削除する
+                SC_Helper_Purchase_Ex::unsetAllShippingTemp(true);
                 try {
                     $arrBuyer = $objAmazonPay->getCheckoutSession($checkoutSessionId);
                     SC_Helper_AmazonPay::log('buyer: '.print_r($arrBuyer, true));


### PR DESCRIPTION
Amazon からお届け先を取得する前に、配送先が設定されている場合は削除する。
Amazon Pay では複数配送が使用できないため、常に Amazon のお届け先を使用する